### PR TITLE
Change .editorconfig end of line setting to CRLF

### DIFF
--- a/client/.editorconfig
+++ b/client/.editorconfig
@@ -1,7 +1,7 @@
 [*.{js,jsx,ts,tsx,vue}]
 indent_style = space
 indent_size = 2
-end_of_line = lf
+end_of_line = crlf
 trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 100


### PR DESCRIPTION
Windows defaults to CRLF line endings, which was causing a linting error
when running `npm run serve` in the `client` directory. This change
remedies those errors.