### PR TITLE
Add configuration code to connect to a database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # npm
 node_modules/
 draco
+
+# Configuration files
+config.yml

--- a/server/config.go
+++ b/server/config.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Config holds important configuration data, such as database
+// credentials. In the future, this type may be expanded to hold server
+// configuration data as well.
+type Config struct {
+	Database struct {
+		Username string `yaml:"user"`
+		Password string `yaml:"pass"`
+		DBName   string `yaml:"dbname"`
+		Host     string `yaml:"host"`
+		Port     string `yaml:"port"`
+	} `yaml:"database"`
+}
+
+// CreatePostgreSQLDBConnString returns a formatted string used the
+// database present in `c`. Uses `sslmode` is `useSSL` is set to true.
+func (c Config) CreatePostgreSQLDBConnString(useSSL bool) string {
+	sslmode := "disable"
+	if useSSL {
+		sslmode = "enable"
+	}
+
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		c.Database.Host,
+		c.Database.Port,
+		c.Database.Username,
+		c.Database.Password,
+		c.Database.DBName,
+		sslmode,
+	)
+}
+
+func createConfigFromFile(path string) *Config {
+	file, err := os.Open(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	c := Config{}
+	if err := yaml.NewDecoder(file).Decode(&c); err != nil {
+		log.Fatal(err)
+	}
+	return &c
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,5 +3,8 @@ module draco
 go 1.15
 
 require (
+	github.com/jmoiron/sqlx v1.3.1
 	github.com/labstack/echo/v4 v4.2.0
+	github.com/lib/pq v1.9.0
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -2,10 +2,16 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/jmoiron/sqlx v1.3.1 h1:aLN7YINNZ7cYOPK3QC83dbM6KT0NMqVMw961TqrejlE=
+github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/labstack/echo/v4 v4.2.0 h1:jkCSsjXmBmapVXF6U4BrSz/cgofWM0CU3Q74wQvXkIc=
 github.com/labstack/echo/v4 v4.2.0/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
+github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7 h1:bQGKb3vps/j0E9GfJQ03JyhRuxsvdAanXlT9BTw3mdw=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -13,6 +19,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -49,3 +56,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/server/main.go
+++ b/server/main.go
@@ -2,21 +2,31 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+
+	_ "github.com/lib/pq"
 )
 
 func main() {
 	portPtr := flag.Int("p", 8080, "Port Number")
+	configFile := flag.String("cfg", "config.yml", "Configuration YAML File")
 	flag.Parse()
 
 	e := echo.New()
 
 	e.Use(middleware.Recover())
 	e.Use(middleware.Logger())
+
+	cfg := createConfigFromFile(*configFile)
+
+	db := initDBConn(cfg.CreatePostgreSQLDBConnString(false))
+	fmt.Println(db)
+
 	e.GET("/", func(c echo.Context) error {
 		return c.HTML(http.StatusOK, `
 			<h1>Hello World!</h1>

--- a/server/storage.go
+++ b/server/storage.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func initDBConn(connString string) *sqlx.DB {
+	db, err := sqlx.Open("postgres", connString)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Ping(); err != nil {
+		log.Fatal((err))
+	}
+	fmt.Println("Successfully connected to database")
+	return db
+}


### PR DESCRIPTION
Created new helper methods which attempt to read in a YAML file that
holds configuration data.

Once read, the configuration is then parsed to create a DB connection
string and a connection is initiated to the database.

Exits immediately if any of these operations fail.