### PR TITLE
Add production flag to the configuration YAML

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -19,6 +19,7 @@ type Config struct {
 		Host     string `yaml:"host"`
 		Port     string `yaml:"port"`
 	} `yaml:"database"`
+	IsProduction bool `yaml:"production"`
 }
 
 // CreatePostgreSQLDBConnString returns a formatted string used the

--- a/server/main.go
+++ b/server/main.go
@@ -29,5 +29,13 @@ func main() {
 
 	e.GET("/test", TestHandler)
 
+	if cfg.IsProduction {
+		// For production builds, we will want to serve the minified
+		// application bundle for frontend codes. This is created using
+		// the `npm run build` command from the `/client/` directory of
+		// the project.
+		e.Static("/", "../client/dist")
+	}
+
 	e.Logger.Fatal(e.Start(":" + strconv.Itoa(*portPtr)))
 }


### PR DESCRIPTION
If the `production` flag is set to true, Go will look for the minified
frontend bundle to serve as a static file.