### PR TITLE
Update YAML config and add sample file

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -20,6 +20,9 @@ type Config struct {
 		Port     string `yaml:"port"`
 	} `yaml:"database"`
 	IsProduction bool `yaml:"production"`
+	HTTPServer   struct {
+		Port int `yaml:"port"`
+	} `yaml:"http_server"`
 }
 
 // CreatePostgreSQLDBConnString returns a formatted string used the

--- a/server/main.go
+++ b/server/main.go
@@ -12,7 +12,6 @@ import (
 )
 
 func main() {
-	portPtr := flag.Int("p", 3000, "Port Number")
 	configFile := flag.String("cfg", "config.yml", "Configuration YAML File")
 	flag.Parse()
 
@@ -37,5 +36,5 @@ func main() {
 		e.Static("/", "../client/dist")
 	}
 
-	e.Logger.Fatal(e.Start(":" + strconv.Itoa(*portPtr)))
+	e.Logger.Fatal(e.Start(":" + strconv.Itoa(cfg.HTTPServer.Port)))
 }

--- a/server/sample_config.yml
+++ b/server/sample_config.yml
@@ -1,0 +1,11 @@
+database:
+  user: your_username
+  pass: your_password
+  dbname: your_database_name
+  host: localhost
+  port: 5432
+
+production: false
+
+http_server:
+  port: 3000


### PR DESCRIPTION
Add new field to the config.yml file "http_server". This field contains
a subfield "port" that serves as a replacement to the previous
command-line implementation of "port".

Add sample_config.yaml, a file which shows the expected format of the
config.yml file.