### PR TITLE
Add new query to fulfill SQL division requirement

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -12,6 +12,32 @@ import (
 	"github.com/labstack/gommon/log"
 )
 
+// Fetches a list of player usernames that have attended each campaign
+// that was created by the requestor.
+func (app *application) getPlayersAttendedAll(c echo.Context) error {
+	dungeonMaster := getUsernameFromToken(c)
+	if strings.TrimSpace(dungeonMaster) == "" {
+		return sendJSONResponse(c, http.StatusUnauthorized,
+			"Campaign stats - Players with perfect attendance in requestor's created campaigns", "Access denied", nil)
+	}
+
+	usernames, err := app.campaigns.GetPlayersAttendedAll(dungeonMaster)
+	if err != nil {
+		log.Error(err)
+		return sendJSONResponse(c, http.StatusUnauthorized,
+			"Campaign stats -  Players with perfect attendance in requestor's created campaigns", "Retrieval failed", nil)
+	}
+
+	return sendJSONResponse(c, http.StatusOK,
+		"Campaign stats - Players with perfect attendance in requestor's created campaigns", "Retrieval successful",
+		struct {
+			Usernames []string `json:"usernames"`
+		}{
+			*usernames,
+		},
+	)
+}
+
 type playerCreationRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`

--- a/server/main.go
+++ b/server/main.go
@@ -44,6 +44,7 @@ type application struct {
 		Insert(c models.Campaign) (int, error)
 		Get(id int) (*models.Campaign, error)
 		GetAllCharacterCampaigns(characterID int)
+		GetPlayersAttendedAll(dungeonMaster string) (*[]string, error)
 	}
 	belongsTo interface {
 		Insert(c models.BelongsTo) error
@@ -87,6 +88,7 @@ func main() {
 		spells:        &postgresql.SpellModel{DB: db},
 		items:         &postgresql.ItemModel{DB: db},
 		stats:         &postgresql.StatsModel{DB: db},
+		campaigns:     &postgresql.CampaignModel{DB: db},
 	}
 
 	if cfg.IsTest {

--- a/server/models/postgresql/campaigns.go
+++ b/server/models/postgresql/campaigns.go
@@ -45,3 +45,39 @@ func (m *CampaignModel) Get(id int) (*models.Campaign, error) {
 
 	return &storedCampaign, nil
 }
+
+func (m *CampaignModel) GetAllCharacterCampaigns(characterID int) {
+	/* TODO: Implement this function */
+}
+
+// GetPlayersAttendedAll fetches the usernames of players which have
+// participated in all campaigns which were created by `dungeonMaster`.
+func (m *CampaignModel) GetPlayersAttendedAll(dungeonMaster string) (*[]string, error) {
+	var storedUsernames []string
+
+	stmt := `SELECT DISTINCT ch.player_username
+			FROM Character ch
+			WHERE NOT EXISTS
+				(SELECT ca.id
+				FROM Campaign ca
+				WHERE ca.dungeon_master = $1 AND ca.id NOT IN
+					(SELECT campaign_id
+					FROM BelongsTo bt
+					WHERE bt.character_id = ch.id))`
+
+	rows, err := m.DB.Queryx(stmt, dungeonMaster)
+	if err != nil {
+		return nil, err
+	}
+
+	for rows.Next() {
+		var username string
+		err = rows.Scan(&username)
+		if err != nil {
+			return nil, err
+		}
+		storedUsernames = append(storedUsernames, username)
+	}
+
+	return &storedUsernames, nil
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -41,4 +41,5 @@ func (app *application) registerRoutes(e *echo.Echo) {
 
 	// Protected campaign endpoints
 	r.POST("/campaign", app.createCampaign)
+	r.GET("/campaign/me/stats/player-attendance", app.getPlayersAttendedAll)
 }


### PR DESCRIPTION
Create new endpoint `/auth/campaign/me/stats/player-attendance` which
fetches a list of player usernames that have participated in all
campaigns created by the requestor.

This endpoint utilizes a query which should fulfill the SQL division
requirement for the project.