### PR TITLE
Spell Creation/Deletion UI

### DIFF
--- a/client/src/components/spells/SpellManagement.vue
+++ b/client/src/components/spells/SpellManagement.vue
@@ -1,0 +1,57 @@
+<!-- CharacterManagement.vue-->
+
+<template>
+  <v-container>
+    <v-card>
+      <!-- Tabs used to select the information page to view. -->
+      <v-tabs v-model="tab" background-color="primary" grow dark>
+        <!-- The individual tab components. -->
+        <v-tab v-for="item in items" :key="item.tab">
+          {{ item.tab }}
+          <v-icon class="ml-2">{{ item.icon }}</v-icon>
+        </v-tab>
+      </v-tabs>
+
+      <!-- Conditionally renders a component based on what tab is
+        selected by the user. -->
+      <v-tabs-items v-model="tab">
+        <v-tab-item v-for="item in items" :key="item.tab">
+          <v-card flat class="secondary">
+            <v-card-text>
+              <component v-bind:is="item.content"> </component>
+            </v-card-text>
+          </v-card>
+        </v-tab-item>
+      </v-tabs-items>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import DeleteSpell from './deletion/SpellDetails.vue';
+import CreateSpell from './creation/CreateSpell.vue';
+
+export default {
+  components: {
+    DeleteSpell,
+    CreateSpell,
+  },
+  data() {
+    return {
+      tab: null,
+      items: [
+        {
+          tab: 'Delete a Spell',
+          content: DeleteSpell,
+          icon: 'mdi-book-open-outline',
+        },
+        {
+          tab: 'Create a Spell',
+          content: CreateSpell,
+          icon: 'mdi-plus',
+        },
+      ],
+    };
+  },
+};
+</script>

--- a/client/src/components/spells/SpellManagement.vue
+++ b/client/src/components/spells/SpellManagement.vue
@@ -1,4 +1,4 @@
-<!-- CharacterManagement.vue-->
+<!-- SpellManagement.vue-->
 
 <template>
   <v-container>
@@ -28,27 +28,27 @@
 </template>
 
 <script>
-import DeleteSpell from './deletion/SpellDetails.vue';
 import CreateSpell from './creation/CreateSpell.vue';
+import DeleteSpell from './deletion/SpellDetails.vue';
 
 export default {
   components: {
-    DeleteSpell,
     CreateSpell,
+    DeleteSpell,
   },
   data() {
     return {
       tab: null,
       items: [
         {
-          tab: 'Delete a Spell',
-          content: DeleteSpell,
-          icon: 'mdi-book-open-outline',
-        },
-        {
           tab: 'Create a Spell',
           content: CreateSpell,
           icon: 'mdi-plus',
+        },
+        {
+          tab: 'Delete a Spell',
+          content: DeleteSpell,
+          icon: 'mdi-book-open-outline',
         },
       ],
     };

--- a/client/src/components/spells/creation/CreateSpell.vue
+++ b/client/src/components/spells/creation/CreateSpell.vue
@@ -1,0 +1,280 @@
+<template>
+  <v-form>
+    <v-container>
+      <v-row>
+        <v-col cols="4">
+          <p class="headline primary--text">Select your character</p>
+          <v-select
+            solo
+            prepend-inner-icon="mdi-account-search"
+            :items="characterNames"
+            v-model="selectedCharName"
+          >
+            <!-- Button used to refresh the character list. -->
+            <template v-slot:append-outer>
+              <v-btn
+                color="primary"
+                fab
+                small
+                class="mt-n2"
+                @click="fetchUserCharacters"
+              >
+                <v-icon>mdi-refresh</v-icon>
+              </v-btn>
+            </template>
+          </v-select>
+        </v-col>
+      </v-row>
+      <v-card v-if="selectedCharName" class="pl-2">
+        <!-- Spell name, shcool, and concentration. -->
+        <p class="headline primary--text">Spell Information</p>
+        <v-row>
+          <v-col cols="12" md="2">
+            <v-text-field
+              v-model.trim="character.name"
+              label="Enter name"
+              outlined
+              required
+              placeholder="Fireball"
+            >
+            </v-text-field>
+          </v-col>
+
+          <v-col cols="12" md="2">
+            <v-select
+              v-model="character.sex"
+              :items="characterSexOptions"
+              label="Choose School"
+              outlined
+              required
+            >
+            </v-select>
+          </v-col>
+
+          <v-col cols="12" md="2">
+            <v-select
+              v-model.trim="character.race"
+              :items="characterRaceOptions"
+              label="Choose Concentration"
+              outlined
+              required
+            >
+            </v-select>
+          </v-col>
+        </v-row>
+
+        <!-- Character weight and height. -->
+        <p class="headline primary--text">Values</p>
+        <v-row>
+          <v-col cols="12" md="2">
+            <v-text-field
+              v-model.trim="character.weight"
+              label="Enter cast time"
+              suffix="s"
+              outlined
+              required
+            >
+            </v-text-field>
+          </v-col>
+
+          <v-col cols="12" md="2">
+            <v-text-field
+              v-model.trim="character.height"
+              label="Enter duration"
+              suffix="s"
+              outlined
+              required
+            >
+            </v-text-field>
+          </v-col>
+
+          <v-col cols="12" md="2">
+            <v-text-field
+              v-model.trim="character.height"
+              label="Enter Range"
+              suffix="s"
+              outlined
+              required
+            >
+            </v-text-field>
+          </v-col>
+        </v-row>
+
+        <!-- Character background. -->
+        <p class="headline primary--text">Description</p>
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-textarea
+              v-model.trim="character.background"
+              label="Enter description"
+              placeholder=""
+              outlined
+              clearable
+              no-resize
+              required
+              counter="250"
+            >
+            </v-textarea>
+          </v-col>
+        </v-row>
+
+        <v-btn class="primary" @click="onComplete">Create</v-btn>
+      </v-card>
+    </v-container>
+  </v-form>
+</template>
+
+<script>
+import { mapActions } from 'vuex';
+
+export default {
+  name: 'CreateSpell',
+  data() {
+    return {
+      character: {},
+      spell: {},
+      selectedCharName: null,
+    };
+  },
+  methods: {
+    ...mapActions({
+      display: 'notifications/display',
+    }),
+    /**
+     * Updates the current character background data. Triggered when the
+     * 'Background' step of the character creation process has been completed.
+     * @param {{
+     *  name: String
+     *  sex: String
+     *  race: String
+     *  weight: String
+     *  height: String
+     *  alignment: String
+     *  background: String
+     *  }} character - The event data emitted after the
+     *  background step has been completed.
+     */
+    updateCharacterBackgroundData({
+      name,
+      sex,
+      race,
+      weight,
+      height,
+      alignment,
+      background,
+    }) {
+      this.character.name = name;
+      this.character.sex = sex;
+      this.character.race = race;
+      this.character.weight = parseInt(weight, 10);
+      this.character.height = parseInt(height, 10);
+      this.character.alignment = alignment;
+      this.character.background = background;
+    },
+    /**
+     * Updates the current character stats data. Triggered when the
+     * 'Stats' step of the character creation process has been completed.
+     * @param {{
+     *  speed: Number
+     *  strength: Number
+     *  dexterity: Number
+     *  intelligence: Number
+     *  wisdom: Number
+     *  charisma: Number
+     *  constitution: Number
+     *  hpMax: Number
+     *  abilityPoints: Number
+     *  xpPoints: Number
+     *  }} character - The event data emitted after the
+     *  stats step has been completed.
+     */
+    updateCharacterStatData({
+      speed,
+      strength,
+      dexterity,
+      intelligence,
+      wisdom,
+      charisma,
+      constitution,
+      hpMax,
+      abilityPoints,
+      xpPoints,
+    }) {
+      this.character.speed = speed;
+      this.character.strength = strength;
+      this.character.dexterity = dexterity;
+      this.character.intelligence = intelligence;
+      this.character.wisdom = wisdom;
+      this.character.charisma = charisma;
+      this.character.constitution = constitution;
+      this.character.hp_max = hpMax;
+      this.character.ability_points = abilityPoints;
+      this.character.xp_points = xpPoints;
+    },
+    /**
+     * Updates the current character class data. Triggered when the
+     * 'Class' step of the character creation process has been completed.
+     * @param {{
+     *  className: String
+     *  classAttributes: Object
+     *  }} character - The event data emitted after the
+     *  class step has been completed.
+     */
+    updateCharacterClassData({ className, classAttributes }) {
+      this.character.class = className;
+      this.character.class_attributes = classAttributes;
+    },
+    /**
+     * Send a request to the backend server's character creation API endpoint.
+     */
+    async sendCharacterCreationRequest() {
+      const requestURI = 'auth/character';
+      const method = 'POST';
+
+      await this.$http({
+        url: requestURI,
+        data: this.character,
+        method,
+      })
+        .then(() => {
+          this.display({
+            message: 'Character was successfully created!',
+            color: 'success',
+            timeout: 6000,
+          });
+        })
+        .catch((err) => {
+          let message = 'Something went wrong. Please try again.';
+          if (err.response) {
+            message = `Error: ${err.response.data.message}. Please try again.`;
+          }
+          this.display({
+            message,
+            color: 'error',
+            timeout: 6000,
+          });
+        });
+    },
+    async fetchUserCharacters() {
+      const requestURI = 'auth/character/me';
+      const method = 'GET';
+
+      await this.$http({
+        url: requestURI,
+        data: null,
+        method,
+      })
+        .then((resp) => {
+          this.characters = resp.data.data.characters;
+          if (this.characters) {
+            const targetChar = this.characters[0];
+            this.selectedCharName = targetChar.name;
+          }
+        })
+        .catch(() => {
+          /* TODO: Add error handling. */
+        });
+    },
+  },
+};
+</script>

--- a/client/src/components/spells/creation/CreateSpell.vue
+++ b/client/src/components/spells/creation/CreateSpell.vue
@@ -1,6 +1,7 @@
 <template>
   <v-form>
     <v-container>
+      <!-- Character selection dropdown -->
       <v-row>
         <v-col cols="4">
           <p class="headline primary--text">Select your character</p>
@@ -25,25 +26,25 @@
           </v-select>
         </v-col>
       </v-row>
-      <v-card v-if="selectedCharName" class="pl-2">
+
+      <v-card class="pl-2">
         <!-- Spell name, shcool, and concentration. -->
         <p class="headline primary--text">Spell Information</p>
         <v-row>
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="character.name"
+              v-model.trim="spell_name"
               label="Enter name"
               outlined
               required
-              placeholder="Fireball"
             >
             </v-text-field>
           </v-col>
 
           <v-col cols="12" md="2">
             <v-select
-              v-model="character.sex"
-              :items="characterSexOptions"
+              v-model="school"
+              :items="schoolOptions"
               label="Choose School"
               outlined
               required
@@ -53,8 +54,8 @@
 
           <v-col cols="12" md="2">
             <v-select
-              v-model.trim="character.race"
-              :items="characterRaceOptions"
+              v-model.trim="concentration"
+              :items="concentrationOptions"
               label="Choose Concentration"
               outlined
               required
@@ -63,12 +64,12 @@
           </v-col>
         </v-row>
 
-        <!-- Character weight and height. -->
+        <!-- Spell cast time, duration, and range. -->
         <p class="headline primary--text">Values</p>
         <v-row>
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="character.weight"
+              v-model.trim="casting_time"
               label="Enter cast time"
               suffix="s"
               outlined
@@ -79,7 +80,7 @@
 
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="character.height"
+              v-model.trim="duration"
               label="Enter duration"
               suffix="s"
               outlined
@@ -90,9 +91,9 @@
 
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="character.height"
+              v-model.trim="range"
               label="Enter Range"
-              suffix="s"
+              suffix="ft"
               outlined
               required
             >
@@ -100,12 +101,12 @@
           </v-col>
         </v-row>
 
-        <!-- Character background. -->
+        <!-- Spell description. -->
         <p class="headline primary--text">Description</p>
         <v-row>
           <v-col cols="12" md="6">
             <v-textarea
-              v-model.trim="character.background"
+              v-model.trim="description"
               label="Enter description"
               placeholder=""
               outlined
@@ -131,130 +132,61 @@ export default {
   name: 'CreateSpell',
   data() {
     return {
-      character: {},
-      spell: {},
+      characters: [],
       selectedCharName: null,
+
+      spellName: '',
+      level: '',
+      school: '',
+      concentration: '',
+      description: '',
+      castingTime: '',
+      range: '',
+      duration: '',
+
+      schoolOptions: [
+        'Abjuration',
+        'Conjuration',
+        'Divination',
+        'Enchantment',
+        'Evocation',
+        'Illusion',
+        'Necromancy',
+        'Transmutation',
+      ],
+      concentrationOptions: ['True', 'False'],
     };
+  },
+  /**
+   * Fetches all of the user's character data when the component loads.
+   * Does not handle fetch errors.
+   * Not sure how to handle spell loading.
+   */
+  async created() {
+    await this.fetchUserCharacters();
+  },
+  computed: {
+    /**
+     * @returns {Array<String>} - The names of the user's characters (if
+     * any).
+     */
+    characterNames() {
+      return this.characters.map((x) => x.name);
+    },
+    /**
+     * @returns {String} - The character currently selected by the user.
+     */
+    selectedCharacter() {
+      if (this.selectedCharName === null) return '';
+
+      const target = this.selectedCharName;
+      return this.characters.filter((x) => x.name === target)[0];
+    },
   },
   methods: {
     ...mapActions({
       display: 'notifications/display',
     }),
-    /**
-     * Updates the current character background data. Triggered when the
-     * 'Background' step of the character creation process has been completed.
-     * @param {{
-     *  name: String
-     *  sex: String
-     *  race: String
-     *  weight: String
-     *  height: String
-     *  alignment: String
-     *  background: String
-     *  }} character - The event data emitted after the
-     *  background step has been completed.
-     */
-    updateCharacterBackgroundData({
-      name,
-      sex,
-      race,
-      weight,
-      height,
-      alignment,
-      background,
-    }) {
-      this.character.name = name;
-      this.character.sex = sex;
-      this.character.race = race;
-      this.character.weight = parseInt(weight, 10);
-      this.character.height = parseInt(height, 10);
-      this.character.alignment = alignment;
-      this.character.background = background;
-    },
-    /**
-     * Updates the current character stats data. Triggered when the
-     * 'Stats' step of the character creation process has been completed.
-     * @param {{
-     *  speed: Number
-     *  strength: Number
-     *  dexterity: Number
-     *  intelligence: Number
-     *  wisdom: Number
-     *  charisma: Number
-     *  constitution: Number
-     *  hpMax: Number
-     *  abilityPoints: Number
-     *  xpPoints: Number
-     *  }} character - The event data emitted after the
-     *  stats step has been completed.
-     */
-    updateCharacterStatData({
-      speed,
-      strength,
-      dexterity,
-      intelligence,
-      wisdom,
-      charisma,
-      constitution,
-      hpMax,
-      abilityPoints,
-      xpPoints,
-    }) {
-      this.character.speed = speed;
-      this.character.strength = strength;
-      this.character.dexterity = dexterity;
-      this.character.intelligence = intelligence;
-      this.character.wisdom = wisdom;
-      this.character.charisma = charisma;
-      this.character.constitution = constitution;
-      this.character.hp_max = hpMax;
-      this.character.ability_points = abilityPoints;
-      this.character.xp_points = xpPoints;
-    },
-    /**
-     * Updates the current character class data. Triggered when the
-     * 'Class' step of the character creation process has been completed.
-     * @param {{
-     *  className: String
-     *  classAttributes: Object
-     *  }} character - The event data emitted after the
-     *  class step has been completed.
-     */
-    updateCharacterClassData({ className, classAttributes }) {
-      this.character.class = className;
-      this.character.class_attributes = classAttributes;
-    },
-    /**
-     * Send a request to the backend server's character creation API endpoint.
-     */
-    async sendCharacterCreationRequest() {
-      const requestURI = 'auth/character';
-      const method = 'POST';
-
-      await this.$http({
-        url: requestURI,
-        data: this.character,
-        method,
-      })
-        .then(() => {
-          this.display({
-            message: 'Character was successfully created!',
-            color: 'success',
-            timeout: 6000,
-          });
-        })
-        .catch((err) => {
-          let message = 'Something went wrong. Please try again.';
-          if (err.response) {
-            message = `Error: ${err.response.data.message}. Please try again.`;
-          }
-          this.display({
-            message,
-            color: 'error',
-            timeout: 6000,
-          });
-        });
-    },
     async fetchUserCharacters() {
       const requestURI = 'auth/character/me';
       const method = 'GET';
@@ -274,6 +206,41 @@ export default {
         .catch(() => {
           /* TODO: Add error handling. */
         });
+    },
+    /**
+     * Updates the current character spell data. Triggered when the
+     * 'Create Button' has been clicked.
+     * @param {{
+     *  spellName: String
+     *  level: String
+     *  school: String
+     *  concentration: String
+     *  description: String
+     *  castingTime: String
+     *  range: String
+     *  duration: String
+     *  }} spell
+     */
+    updateCharacterSpellData({
+      charID,
+      spellName,
+      level,
+      school,
+      concentration,
+      description,
+      castingTime,
+      range,
+      duration,
+    }) {
+      this.spell.characterId = charID;
+      this.spell.spellName = spellName;
+      this.spell.level = parseInt(level, 10);
+      this.spell.school = school;
+      this.spell.concentration = concentration;
+      this.spell.description = description;
+      this.spell.castingTime = parseInt(castingTime, 10);
+      this.spell.range = parseInt(range, 10);
+      this.spell.duration = parseInt(duration, 10);
     },
   },
 };

--- a/client/src/components/spells/deletion/SpellDetails.vue
+++ b/client/src/components/spells/deletion/SpellDetails.vue
@@ -1,0 +1,307 @@
+<!-- SpellDetails.vue -->
+<!-- Displays all details for a specific character's spells.
+The player is then able to delete the spell. -->
+
+<template>
+  <v-container class="character-info">
+    <!-- Character selection dropdown -->
+    <v-row>
+      <v-col cols="4">
+        <p class="headline primary--text">Select your character</p>
+        <v-select
+          solo
+          prepend-inner-icon="mdi-account-search"
+          :items="characterNames"
+          v-model="selectedCharName"
+        >
+          <!-- Button used to refresh the character list. -->
+          <template v-slot:append-outer>
+            <v-btn
+              color="primary"
+              fab
+              small
+              class="mt-n2"
+              @click="fetchUserCharacters"
+            >
+              <v-icon>mdi-refresh</v-icon>
+            </v-btn>
+          </template>
+        </v-select>
+      </v-col>
+    </v-row>
+
+    <!-- Spell selection dropdown -->
+    <v-row>
+      <v-col v-if="selectedCharName" cols="4">
+        <p class="headline primary--text">Select your spell</p>
+        <v-select
+          v-if="selectedCharName"
+          solo
+          prepend-inner-icon="mdi-account-search"
+          :items="characterNames"
+          v-model="selectedSpellName"
+        >
+          <!-- Button used to refresh the spell list. -->
+          <template v-slot:append-outer>
+            <v-btn
+              color="primary"
+              fab
+              small
+              class="mt-n2"
+              @click="fetchCharacterSpells(selectedCharacter.id)"
+            >
+              <v-icon>mdi-refresh</v-icon>
+            </v-btn>
+          </template>
+        </v-select>
+      </v-col>
+    </v-row>
+
+    <!-- Spell Name and Character ID -->
+    <v-card v-if="selectedCharName" class="pl-2">
+      <v-card-title class="display-1 primary--text">
+        {{ characterSpells[0].spell_name }}
+      </v-card-title>
+      <v-card-subtitle>
+        Character ID: {{ selectedCharacter.id }}
+      </v-card-subtitle>
+
+      <!-- Delete button -->
+      <v-card-actions>
+        <v-btn class="error" @click="displayCharacterDeletionPrompt">
+          Delete {{ spellNames[0] }}
+          <v-icon class="ml-2">mdi-delete-forever</v-icon>
+        </v-btn>
+
+        <ConfirmDialog ref="confirmDelete" />
+      </v-card-actions>
+
+      <!-- This container displays all spell information -->
+      <v-container>
+        <p class="headline primary--text">Spell Information</p>
+        <v-row>
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Level"
+              :value="characterSpells[0].level"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="School"
+              :value="characterSpells[0].school"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Concentration"
+              :value="characterSpells[0].concentration"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Casting Time"
+              :value="characterSpells[0].casting_time"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Range"
+              :value="characterSpells[0].range"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Duration"
+              :value="characterSpells[0].duration"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col cols="12" lg="12">
+            <v-textarea
+              readonly
+              no-resize
+              label="Description"
+              outlined
+              :value="characterSpells[0].description"
+            ></v-textarea>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import { mapActions } from 'vuex';
+import ConfirmDialog from '@/components/ConfirmDialog.vue';
+
+export default {
+  name: 'SpellDetails',
+  components: {
+    ConfirmDialog,
+  },
+  data() {
+    return {
+      characters: [],
+      selectedCharName: null,
+      spells: [],
+      selectedSpellName: null,
+    };
+  },
+  /**
+   * Fetches all of the user's character data when the component loads.
+   * Does not handle fetch errors.
+   * Not sure how to handle spell loading.
+   */
+  async created() {
+    await this.fetchUserCharacters();
+    await this.fetchCharacterSpells(61);
+  },
+  computed: {
+    /**
+     * @returns {Array<String>} - The names of the user's characters (if
+     * any).
+     */
+    characterNames() {
+      return this.characters.map((x) => x.name);
+    },
+    /**
+     * @returns {Array<String>} - The names of the user's spell (if
+     * any).
+     */
+    spellNames() {
+      return this.data.map((x) => x.spell_name);
+    },
+    /**
+     * @returns {String} - The character currently selected by the user.
+     */
+    selectedCharacter() {
+      if (this.selectedCharName === null) return '';
+
+      const target = this.selectedCharName;
+      return this.characters.filter((x) => x.name === target)[0];
+    },
+    /**
+     * @returns {String} - The spell currently selected by the user.
+     */
+    selectedSpell() {
+      if (this.selectedSpellName === null) return '';
+
+      const target = this.selectedSpellName;
+      return this.spells.filter((x) => x.spell_name === target)[0];
+    },
+  },
+  methods: {
+    ...mapActions({
+      display: 'notifications/display',
+    }),
+    /**
+     * Sends an HTTP request to fetch the user's characters.
+     */
+    async fetchUserCharacters() {
+      const requestURI = 'auth/character/me';
+      const method = 'GET';
+
+      await this.$http({
+        url: requestURI,
+        data: null,
+        method,
+      })
+        .then((resp) => {
+          this.characters = resp.data.data.characters;
+          if (this.characters) {
+            const targetChar = this.characters[0];
+            this.selectedCharName = targetChar.name;
+          }
+        })
+        .catch(() => {
+          /* TODO: Add error handling. */
+        });
+    },
+    /**
+     * @param {String} charID - The character ID which can help to identify the spells
+     * to fetch.
+     */
+    async fetchCharacterSpells(charID) {
+      const integerID = parseInt(charID, 10);
+
+      const requestURI = `auth/character/${integerID}/spell`;
+      const method = 'GET';
+
+      await this.$http({
+        url: requestURI,
+        data: null,
+        method,
+      })
+        .then((resp) => {
+          this.characterSpells = resp.data.data.spells;
+          this.data = this.characterSpells;
+        })
+        .catch(() => {
+          /* TODO: Add error handling. */
+        });
+    },
+    /**
+     * Displays a prompt to the user, asking them to confirm their
+     * character deletion.
+     */
+    async displayCharacterDeletionPrompt() {
+      const title = 'Confirm deletion';
+      const message = 'Delete your character? This action is irreversible.';
+      if (await this.$refs.confirmDelete.prompt(title, message)) {
+        await this.requestCharacterDeletion();
+      }
+    },
+    /**
+     * Sends an HTTP request to delete the user's character.
+     */
+    async requestCharacterDeletion() {
+      const integerID = parseInt(this.selectedCharacter.id, 10);
+
+      const requestURI = `auth/character/${integerID}`;
+      const method = 'DELETE';
+
+      await this.$http({
+        url: requestURI,
+        data: null,
+        method,
+      })
+        .then(() => {
+          this.display({
+            message: 'Character was successfully deleted!',
+            color: 'success',
+            timeout: 6000,
+          });
+        })
+        .catch((err) => {
+          let message = 'Something went wrong. Please try again.';
+          if (err.response) {
+            message = `Error: ${err.response.data.message}. Please try again.`;
+          }
+          this.display({
+            message,
+            color: 'error',
+            timeout: 6000,
+          });
+        })
+        .finally(() => {
+          this.fetchUserCharacters();
+        });
+    },
+  },
+};
+</script>

--- a/client/src/layouts/NavDrawer.vue
+++ b/client/src/layouts/NavDrawer.vue
@@ -41,6 +41,7 @@ export default {
         { title: 'Dashboard', icon: 'mdi-view-dashboard', to: '/dashboard' },
         { title: 'My account', icon: 'mdi-account-box', to: '/account' },
         { title: 'Character management', icon: 'mdi-gavel', to: '/characters' },
+        { title: 'Spell management', icon: 'mdi-gavel', to: '/spells' },
         { title: 'Start a campaign', icon: 'mdi-castle', to: '/campaign' },
       ],
     };

--- a/client/src/layouts/NavDrawer.vue
+++ b/client/src/layouts/NavDrawer.vue
@@ -41,7 +41,7 @@ export default {
         { title: 'Dashboard', icon: 'mdi-view-dashboard', to: '/dashboard' },
         { title: 'My account', icon: 'mdi-account-box', to: '/account' },
         { title: 'Character management', icon: 'mdi-gavel', to: '/characters' },
-        { title: 'Spell management', icon: 'mdi-gavel', to: '/spells' },
+        { title: 'Spell management', icon: 'mdi-fire', to: '/spells' },
         { title: 'Start a campaign', icon: 'mdi-castle', to: '/campaign' },
       ],
     };

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -63,6 +63,15 @@ const routes = [
       protected: true,
     },
   },
+  {
+    path: '/spells',
+    name: 'Spells',
+    component: () => import('../views/Spells.vue'),
+    meta: {
+      layout: 'Main',
+      protected: true,
+    },
+  },
 ];
 
 const router = new VueRouter({

--- a/client/src/views/Spells.vue
+++ b/client/src/views/Spells.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="characters">
+    <SpellManagement />
+  </div>
+</template>
+
+<script>
+import SpellManagement from '../components/spells/SpellManagement.vue';
+
+export default {
+  name: 'Spells',
+  components: {
+    SpellManagement,
+  },
+};
+</script>


### PR DESCRIPTION
Below are two images of the pages in this pull request. The pages are not connected to the backend yet, with a few exceptions:

- Character Select on Creation Page
- Character Select on Deletion Page
- Spell Select on Deletion Page (This is hard coded to character id 61 right now)

I need help figuring out how to load in the spells from a character. I need to load them after the character has been selected, but I am having a really hard time figuring this out. I am using your code for spells from the dashboard page. 

You can see the problem on **line 24 and 198 of SpellDetails.vue** . The current code wants me to fetch the character spells at created, but I cannot access the characterID at this point. That's why I temp have it fetching the first character you've added to the DB for testing.

On line 159 I have the selectedSpellIndex. This will be used or replaced when I can get the Spell Selection Dropdown working. 

@knsjerome Please leave comments if you have any ideas on how to solve the loading of the Spells after Characters. I will see them first thing in the morning.

![image](https://user-images.githubusercontent.com/47066061/114339358-d970ee80-9b09-11eb-81aa-f092467f4697.png)

![image](https://user-images.githubusercontent.com/47066061/114339379-e261c000-9b09-11eb-8fbf-faf783f512f2.png)
