### PR TITLE
Fix unhandled null case in authentication store causing failed logins

### DIFF
--- a/client/src/store/modules/authentication.js
+++ b/client/src/store/modules/authentication.js
@@ -16,7 +16,7 @@ const getters = {
 const mutations = {
   onLoginSuccess(state, { token, username }) {
     state.token = token;
-    state.player.username = username;
+    state.player = { username };
   },
   onLogout(state) {
     state.token = null;


### PR DESCRIPTION
Fixed bug where the a property of a player state was being accessed when
the player state itself was null.