### PR TITLE
45 make create campaign page client http

### DIFF
--- a/client/src/components/campaign/AddCharacterDialog.vue
+++ b/client/src/components/campaign/AddCharacterDialog.vue
@@ -25,6 +25,9 @@ add a new character to their campaign.
           :counter="50"
           label="ID"
           required
+          :error-messages="idErrors"
+          @input="$v.id.$touch()"
+          @blur="$v.id.touch()"
         ></v-text-field>
 
         <v-card-actions class="pt-4">
@@ -38,6 +41,11 @@ add a new character to their campaign.
 </template>
 
 <script>
+import {
+  required,
+  numeric,
+} from 'vuelidate/lib/validators';
+
 export default {
   name: 'AddCharacterDialog',
   data() {
@@ -47,6 +55,12 @@ export default {
       reject: null,
       id: null,
     };
+  },
+  validations: {
+    id: {
+      required,
+      numeric,
+    },
   },
   methods: {
     prompt() {
@@ -60,8 +74,12 @@ export default {
      * Runs when the user accepts the prompt. Closes the prompt.
      */
     accept() {
+      this.$v.$touch();
+      if (this.$v.$invalid) return;
+
       this.resolve(true);
       this.showPrompt = false;
+      this.$v.$reset();
     },
     /**
      * Runs when the user declines the prompt. Closes the prompt. Can be
@@ -70,6 +88,29 @@ export default {
     decline() {
       this.resolve(false);
       this.showPrompt = false;
+      this.$v.$reset();
+    },
+    /**
+     * Clears ID from the text box
+     */
+    clearID() {
+      this.id = null;
+    },
+  },
+  computed: {
+    idErrors() {
+      const errors = [];
+      if (!this.$v.id.$dirty) return errors;
+      if (!this.$v.id.required) {
+        errors.push('ID is required.');
+      }
+      if (!this.$v.id.numeric) {
+        errors.push('ID must be numeric.');
+      }
+      return errors;
+    },
+    getID() {
+      return this.id;
     },
   },
 };

--- a/client/src/components/campaign/AddCharacterDialog.vue
+++ b/client/src/components/campaign/AddCharacterDialog.vue
@@ -44,6 +44,7 @@ add a new character to their campaign.
 import {
   required,
   numeric,
+  maxLength,
 } from 'vuelidate/lib/validators';
 
 export default {
@@ -60,6 +61,7 @@ export default {
     id: {
       required,
       numeric,
+      maxLength: maxLength(50),
     },
   },
   methods: {
@@ -106,6 +108,9 @@ export default {
       }
       if (!this.$v.id.numeric) {
         errors.push('ID must be numeric.');
+      }
+      if (!this.$v.id.maxLength) {
+        errors.push('Max length exceeded.');
       }
       return errors;
     },

--- a/client/src/components/campaign/AddCharacterDialog.vue
+++ b/client/src/components/campaign/AddCharacterDialog.vue
@@ -27,7 +27,7 @@ add a new character to their campaign.
           required
           :error-messages="idErrors"
           @input="$v.id.$touch()"
-          @blur="$v.id.touch()"
+          @blur="$v.id.$touch()"
         ></v-text-field>
 
         <v-card-actions class="pt-4">

--- a/client/src/components/campaign/AddCharacterTable.vue
+++ b/client/src/components/campaign/AddCharacterTable.vue
@@ -52,5 +52,10 @@ export default {
       this.items = this.items.filter((x) => x.id !== id);
     },
   },
+  computed: {
+    getItems() {
+      return this.items;
+    },
+  },
 };
 </script>

--- a/client/src/components/campaign/AddCharacterTable.vue
+++ b/client/src/components/campaign/AddCharacterTable.vue
@@ -56,6 +56,9 @@ export default {
     getItems() {
       return this.items;
     },
+    getIDs() {
+      return this.items.map(({ id }) => parseInt(id, 10));
+    },
   },
 };
 </script>

--- a/client/src/components/campaign/CampaignForm.vue
+++ b/client/src/components/campaign/CampaignForm.vue
@@ -67,11 +67,58 @@ export default {
     AddCharacterDialog,
     AddCharacterTable,
   },
+  data() {
+    return {
+      idExists: false,
+      tempCharacter: null,
+    };
+  },
   methods: {
+    /**
+     * Displays prompt that asks user to enter a character ID
+     */
     async showAddCharacterDialog() {
       if (await this.$refs.addCharacterDialog.prompt()) {
-        await this.$refs.addCharacterTable.addItem('null', 'null', 'null'); // Test values for now
+        const id = this.$refs.addCharacterDialog.getID;
+
+        await this.fetchCharacterInfo(id);
+
+        if (!this.idExists) return;
+
+        this.$refs.addCharacterTable.addItem(
+          id,
+          this.tempCharacter.cName,
+          this.tempCharacter.cOwner,
+        );
       }
+      this.$refs.addCharacterDialog.clearID();
+      this.idExists = false;
+      this.tempCharacter = null;
+    },
+    /**
+     * Fetches character and owner names based on ID number, and places
+     * the information in "tempCharacter"
+     */
+    async fetchCharacterInfo(id) {
+      const integerID = parseInt(id, 10);
+      const requestURI = `auth/character/${integerID}`;
+      const method = 'GET';
+
+      await this.$http({
+        url: requestURI,
+        data: null,
+        method,
+      })
+        .then((resp) => {
+          this.tempCharacter = {
+            cName: resp.data.data.name,
+            cOwner: resp.data.data.player_username,
+          };
+          this.idExists = true;
+        })
+        .catch(() => {
+          /* TODO: Notify user of invalid ID */
+        });
     },
   },
 };

--- a/client/src/components/campaign/CampaignForm.vue
+++ b/client/src/components/campaign/CampaignForm.vue
@@ -22,6 +22,9 @@ campaign. Assumes the user is authenticated.
               :counter="50"
               label="Campaign Name"
               required
+              :error-messages="nameErrors"
+              @input="$v.name.$touch()"
+              @blur="$v.name.touch()"
             ></v-text-field>
           </v-col>
 
@@ -31,6 +34,9 @@ campaign. Assumes the user is authenticated.
               :counter="50"
               label="Location"
               required
+              :error-messages="locationErrors"
+              @input="$v.location.$touch()"
+              @blur="$v.location.touch()"
             ></v-text-field>
           </v-col>
         </v-row>
@@ -40,6 +46,10 @@ campaign. Assumes the user is authenticated.
             v-model="state"
             filled
             label="Current State"
+            required
+            :error-messages="stateErrors"
+            @input="$v.state.$touch()"
+            @blur="$v.state.touch()"
           ></v-textarea>
         </v-row>
 
@@ -56,7 +66,7 @@ campaign. Assumes the user is authenticated.
         <v-row class="ml-0 mt-10">
           <v-btn
             color="primary"
-            @click="requestCampaignCreation()"
+            @click="onClickCreate()"
           >Create</v-btn>
         </v-row>
 
@@ -67,6 +77,9 @@ campaign. Assumes the user is authenticated.
 </template>
 
 <script>
+import {
+  required,
+} from 'vuelidate/lib/validators';
 import AddCharacterDialog from './AddCharacterDialog.vue';
 import AddCharacterTable from './AddCharacterTable.vue';
 
@@ -85,10 +98,27 @@ export default {
       tempCharacter: null,
     };
   },
+  validations: {
+    name: {
+      required,
+    },
+    location: {
+      required,
+    },
+    state: {
+      required,
+    },
+  },
   methods: {
     /**
      * Displays prompt that asks user to enter a character ID
      */
+    async onClickCreate() {
+      this.$v.$touch();
+      if (this.$v.$invalid) return;
+      this.$v.$reset();
+      this.requestCampaignCreation();
+    },
     async showAddCharacterDialog() {
       if (await this.$refs.addCharacterDialog.prompt()) {
         const id = this.$refs.addCharacterDialog.getID;
@@ -154,6 +184,32 @@ export default {
         .catch(() => {
           /* TODO: Add error handling */
         });
+    },
+  },
+  computed: {
+    nameErrors() {
+      const errors = [];
+      if (!this.$v.name.$dirty) return errors;
+      if (!this.$v.name.required) {
+        errors.push('Name is required.');
+      }
+      return errors;
+    },
+    locationErrors() {
+      const errors = [];
+      if (!this.$v.location.$dirty) return errors;
+      if (!this.$v.location.required) {
+        errors.push('Location is required.');
+      }
+      return errors;
+    },
+    stateErrors() {
+      const errors = [];
+      if (!this.$v.state.$dirty) return errors;
+      if (!this.$v.state.required) {
+        errors.push('State is required.');
+      }
+      return errors;
     },
   },
 };

--- a/client/src/components/campaign/CampaignForm.vue
+++ b/client/src/components/campaign/CampaignForm.vue
@@ -44,6 +44,7 @@ campaign. Assumes the user is authenticated.
         <v-row>
           <v-textarea
             v-model="state"
+            :counter="1024"
             filled
             label="Current State"
             required
@@ -79,6 +80,7 @@ campaign. Assumes the user is authenticated.
 <script>
 import {
   required,
+  maxLength,
 } from 'vuelidate/lib/validators';
 import AddCharacterDialog from './AddCharacterDialog.vue';
 import AddCharacterTable from './AddCharacterTable.vue';
@@ -101,12 +103,15 @@ export default {
   validations: {
     name: {
       required,
+      maxLength: maxLength(50),
     },
     location: {
       required,
+      maxLength: maxLength(50),
     },
     state: {
       required,
+      maxLength: maxLength(1024),
     },
   },
   methods: {
@@ -193,6 +198,9 @@ export default {
       if (!this.$v.name.required) {
         errors.push('Name is required.');
       }
+      if (!this.$v.name.maxLength) {
+        errors.push('Max length exceeded.');
+      }
       return errors;
     },
     locationErrors() {
@@ -201,6 +209,9 @@ export default {
       if (!this.$v.location.required) {
         errors.push('Location is required.');
       }
+      if (!this.$v.location.maxLength) {
+        errors.push('Max length exceeded.');
+      }
       return errors;
     },
     stateErrors() {
@@ -208,6 +219,9 @@ export default {
       if (!this.$v.state.$dirty) return errors;
       if (!this.$v.state.required) {
         errors.push('State is required.');
+      }
+      if (!this.$v.state.maxLength) {
+        errors.push('Max length exceeded.');
       }
       return errors;
     },

--- a/client/src/components/campaign/CampaignForm.vue
+++ b/client/src/components/campaign/CampaignForm.vue
@@ -18,6 +18,7 @@ campaign. Assumes the user is authenticated.
         <v-row class="mb-3">
           <v-col cols="12" md="6">
             <v-text-field
+              v-model="name"
               :counter="50"
               label="Campaign Name"
               required
@@ -26,6 +27,7 @@ campaign. Assumes the user is authenticated.
 
           <v-col cols="12" md="6">
             <v-text-field
+              v-model="location"
               :counter="50"
               label="Location"
               required
@@ -34,7 +36,11 @@ campaign. Assumes the user is authenticated.
         </v-row>
 
         <v-row>
-          <v-textarea filled label="Current State"></v-textarea>
+          <v-textarea
+            v-model="state"
+            filled
+            label="Current State"
+          ></v-textarea>
         </v-row>
 
         <v-row class="ml-n2 mb-1">
@@ -48,7 +54,10 @@ campaign. Assumes the user is authenticated.
         </v-row>
 
         <v-row class="ml-0 mt-10">
-          <v-btn color="primary">Create</v-btn>
+          <v-btn
+            color="primary"
+            @click="requestCampaignCreation()"
+          >Create</v-btn>
         </v-row>
 
         <AddCharacterDialog ref="addCharacterDialog" />
@@ -69,6 +78,9 @@ export default {
   },
   data() {
     return {
+      name: '',
+      location: '',
+      state: '',
       idExists: false,
       tempCharacter: null,
     };
@@ -83,7 +95,7 @@ export default {
 
         await this.fetchCharacterInfo(id);
 
-        if (!this.idExists) return;
+        if (!this.idExists) return; // TODO: Notify user of invalid id
 
         this.$refs.addCharacterTable.addItem(
           id,
@@ -117,7 +129,30 @@ export default {
           this.idExists = true;
         })
         .catch(() => {
-          /* TODO: Notify user of invalid ID */
+          /* TODO: Add error handling */
+        });
+    },
+    /**
+     * Sends HTTP requests to create a new campaign
+     */
+    async requestCampaignCreation() {
+      const requestURI = 'auth/campaign';
+      const data = {
+        campaign: {
+          name: this.name,
+          current_location: this.location,
+          state: this.state,
+        },
+        character_id: this.$refs.addCharacterTable.getIDs,
+      };
+      const method = 'POST';
+
+      await this.$http({ url: requestURI, data, method })
+        .then(() => {
+          this.$router.push('/dashboard');
+        })
+        .catch(() => {
+          /* TODO: Add error handling */
         });
     },
   },

--- a/client/src/components/campaign/CampaignForm.vue
+++ b/client/src/components/campaign/CampaignForm.vue
@@ -24,7 +24,7 @@ campaign. Assumes the user is authenticated.
               required
               :error-messages="nameErrors"
               @input="$v.name.$touch()"
-              @blur="$v.name.touch()"
+              @blur="$v.name.$touch()"
             ></v-text-field>
           </v-col>
 
@@ -36,7 +36,7 @@ campaign. Assumes the user is authenticated.
               required
               :error-messages="locationErrors"
               @input="$v.location.$touch()"
-              @blur="$v.location.touch()"
+              @blur="$v.location.$touch()"
             ></v-text-field>
           </v-col>
         </v-row>
@@ -49,7 +49,7 @@ campaign. Assumes the user is authenticated.
             required
             :error-messages="stateErrors"
             @input="$v.state.$touch()"
-            @blur="$v.state.touch()"
+            @blur="$v.state.$touch()"
           ></v-textarea>
         </v-row>
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -494,23 +494,10 @@ func (app *application) createCampaign(c echo.Context) error {
 
 	req.CampaignInfo.DungeonMaster = creatorUsername
 
-	campaignId, err := app.campaigns.Insert(req.CampaignInfo)
+	campaignId, err := app.campaigns.Insert(req.CampaignInfo, req.CharacterId)
 	if err != nil {
 		log.Error(err)
 		return sendJSONResponse(c, http.StatusInternalServerError, "Campaign creation", "Creation failed", nil)
-	}
-
-	relationship := models.BelongsTo{
-		CharacterID: 0,
-		CampaignID:  campaignId,
-	}
-	for _, id := range req.CharacterId {
-		relationship.CharacterID = id
-		err = app.belongsTo.Insert(relationship)
-		if err != nil {
-			log.Error(err)
-			return sendJSONResponse(c, http.StatusInternalServerError, "Campaign creation", "Creation failed", nil)
-		}
 	}
 
 	return sendJSONResponse(c, http.StatusCreated, "Campaign creation", "Creation successful",

--- a/server/main.go
+++ b/server/main.go
@@ -43,7 +43,7 @@ type application struct {
 		GetTotalWeightCharacterItems(characterID int) (int, error)
 	}
 	campaigns interface {
-		Insert(c models.Campaign) (int, error)
+		Insert(c models.Campaign, characterIDs []int) (int, error)
 		Get(id int) (*models.Campaign, error)
 		GetAllCharacterCampaigns(characterID int)
 		GetPlayersAttendedAll(dungeonMaster string) (*[]string, error)

--- a/server/main.go
+++ b/server/main.go
@@ -89,8 +89,9 @@ func main() {
 		characters:    &postgresql.CharacterModel{DB: db},
 		spells:        &postgresql.SpellModel{DB: db},
 		items:         &postgresql.ItemModel{DB: db},
-		stats:         &postgresql.StatsModel{DB: db},
 		campaigns:     &postgresql.CampaignModel{DB: db},
+		belongsTo:     &postgresql.BelongsToModel{DB: db},
+		stats:         &postgresql.StatsModel{DB: db},
 	}
 
 	if cfg.IsTest {

--- a/server/models/postgresql/belongs_to.go
+++ b/server/models/postgresql/belongs_to.go
@@ -12,7 +12,7 @@ type BelongsToModel struct {
 	DB *sqlx.DB
 }
 
-func (m BelongsToModel) Insert(c models.BelongsTo) error {
+func (m *BelongsToModel) Insert(c models.BelongsTo) error {
 	stmt := `INSERT INTO BelongsTo (character_id, campaign_id)
 		VALUES($1, $2)`
 
@@ -26,7 +26,6 @@ func (m BelongsToModel) Insert(c models.BelongsTo) error {
 		}
 		return err
 	}
-
 	return nil
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -45,4 +45,5 @@ func (app *application) registerRoutes(e *echo.Echo) {
 	// Protected campaign endpoints
 	r.POST("/campaign", app.createCampaign)
 	r.GET("/campaign/me/stats/player-attendance", app.getPlayersAttendedAll)
+	//r.POST("/campaign/:id/players", app.addCharacterToCampaign)
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -25,6 +25,7 @@ func (app *application) registerRoutes(e *echo.Echo) {
 	// Protected character endpoints
 	r.POST("/character", app.createCharacter)
 	r.GET("/character/me", app.retrieveUserCharacters)
+	r.GET("/character/:id", app.retrieveCharacter)
 	r.DELETE("/character/:id", app.deleteCharacter)
 
 	// Protected spell endpoints

--- a/server/sql/init_db.sql
+++ b/server/sql/init_db.sql
@@ -146,9 +146,9 @@ CREATE TABLE Spells (
 
 CREATE TABLE Campaign (
     id                  serial PRIMARY KEY,
-    name                text NOT NULL,
-    current_location    text NOT NULL,
-    state               text,
+    name                varchar(50) NOT NULL,
+    current_location    varchar(50) NOT NULL,
+    state               varchar(1024),
     dungeon_master      varchar(25),
     FOREIGN KEY (dungeon_master) REFERENCES Player(username)
         ON DELETE SET NULL

--- a/server/sql/populate_db.sql
+++ b/server/sql/populate_db.sql
@@ -359,3 +359,8 @@ INSERT INTO BelongsTo VALUES
     4,
     2
 );
+
+
+-- Manually reset primary key indeces so that "serial" values continue from correct location
+SELECT setval(pg_get_serial_sequence('Character', 'id'), (SELECT MAX(id) FROM Character));
+SELECT setval(pg_get_serial_sequence('Campaign', 'id'), (SELECT MAX(id) FROM Campaign));


### PR DESCRIPTION
Make the "Start a campaign" page issue an HTTP request when the "Create" button is pressed. This performs one insert operation into the "Campaign" table, and a variable number of Insert operations into the "BelongsTo" table depending on how many characters were added. Also adds form validation for the Campaign form.

Images:

![image](https://user-images.githubusercontent.com/16463725/114611688-295ccc00-9c56-11eb-92d4-afbc21e035da.png)
![image](https://user-images.githubusercontent.com/16463725/114611713-2f52ad00-9c56-11eb-8aa4-449fe0b6dc28.png)
![image](https://user-images.githubusercontent.com/16463725/114611734-34176100-9c56-11eb-901d-48a354b4433b.png)

