### PR TITLE
Item Creation/Deletion UI Pages -- Frontend Only

### DIFF
--- a/client/src/components/items/ItemManagement.vue
+++ b/client/src/components/items/ItemManagement.vue
@@ -1,0 +1,57 @@
+<!-- ItemManagement.vue-->
+
+<template>
+  <v-container>
+    <v-card>
+      <!-- Tabs used to select the information page to view. -->
+      <v-tabs v-model="tab" background-color="primary" grow dark>
+        <!-- The individual tab components. -->
+        <v-tab v-for="item in items" :key="item.tab">
+          {{ item.tab }}
+          <v-icon class="ml-2">{{ item.icon }}</v-icon>
+        </v-tab>
+      </v-tabs>
+
+      <!-- Conditionally renders a component based on what tab is
+        selected by the user. -->
+      <v-tabs-items v-model="tab">
+        <v-tab-item v-for="item in items" :key="item.tab">
+          <v-card flat class="secondary">
+            <v-card-text>
+              <component v-bind:is="item.content"> </component>
+            </v-card-text>
+          </v-card>
+        </v-tab-item>
+      </v-tabs-items>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import CreateItem from './creation/CreateItem.vue';
+import DeleteItem from './deletion/ItemDetails.vue';
+
+export default {
+  components: {
+    CreateItem,
+    DeleteItem,
+  },
+  data() {
+    return {
+      tab: null,
+      items: [
+        {
+          tab: 'Create an Item',
+          content: CreateItem,
+          icon: 'mdi-plus',
+        },
+        {
+          tab: 'Delete an Item',
+          content: DeleteItem,
+          icon: 'mdi-shield-remove-outline',
+        },
+      ],
+    };
+  },
+};
+</script>

--- a/client/src/components/items/creation/CreateItem.vue
+++ b/client/src/components/items/creation/CreateItem.vue
@@ -28,13 +28,13 @@
       </v-row>
 
       <v-card class="pa-4" v-if="selectedCharacter">
-        <!-- Spell name, school, and concentration. -->
+        <!-- Item name, type, and rarity. -->
         <p class="headline primary--text">General information</p>
         <v-row>
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="spell.name"
-              label="Enter spell name"
+              v-model.trim="item.name"
+              label="Enter item name"
               outlined
               required
             >
@@ -43,9 +43,9 @@
 
           <v-col cols="12" md="2">
             <v-select
-              v-model="spell.school"
-              :items="schoolOptions"
-              label="Choose school"
+              v-model="item.type"
+              :items="typeOptions"
+              label="Choose item type"
               outlined
               required
             >
@@ -54,9 +54,9 @@
 
           <v-col cols="12" md="2">
             <v-select
-              v-model.trim="spell.concentration"
-              :items="concentrationOptions"
-              label="Choose concentration"
+              v-model.trim="item.rarity"
+              :items="rarityOptions"
+              label="Choose rarity"
               outlined
               required
             >
@@ -64,13 +64,14 @@
           </v-col>
         </v-row>
 
-        <!-- Spell level, casting time, duration, and range. -->
+        <!-- Item level, weight, gold value, and quantity. -->
         <p class="headline primary--text">Numeric details</p>
         <v-row>
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="spell.level"
-              label="Enter level number"
+              v-model.trim="item.weight"
+              label="Enter item weight"
+              suffix="lbs"
               outlined
               required
             >
@@ -79,9 +80,9 @@
 
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="spell.casting_time"
-              label="Enter casting time"
-              suffix="s"
+              v-model.trim="item.goldValue"
+              label="Enter item's gold value"
+              suffix="gold"
               outlined
               required
             >
@@ -90,20 +91,8 @@
 
           <v-col cols="12" md="2">
             <v-text-field
-              v-model.trim="spell.duration"
-              label="Enter duration"
-              suffix="s"
-              outlined
-              required
-            >
-            </v-text-field>
-          </v-col>
-
-          <v-col cols="12" md="2">
-            <v-text-field
-              v-model.trim="spell.range"
-              label="Enter range"
-              suffix="ft"
+              v-model.trim="item.quantity"
+              label="Enter quantity of item(s)"
               outlined
               required
             >
@@ -111,12 +100,12 @@
           </v-col>
         </v-row>
 
-        <!-- Spell description. -->
+        <!-- Item description. -->
         <p class="headline primary--text">Description</p>
         <v-row>
           <v-col cols="12" md="6">
             <v-textarea
-              v-model.trim="spell.description"
+              v-model.trim="item.description"
               label="Enter description"
               placeholder=""
               outlined
@@ -139,35 +128,42 @@
 import { mapActions } from 'vuex';
 
 export default {
-  name: 'CreateSpell',
+  name: 'CreateItem',
   data() {
     return {
       characters: [],
       selectedCharName: null,
 
-      spell: {
+      item: {
         name: '',
-        school: 'Abjuration',
-        concentration: true,
-        level: 0,
-        casting_time: 5,
-        duration: 1,
-        range: 10,
-        description: 'Blasts a foe into oblivion.',
+        type: 'Armor',
+        rarity: 'Common',
+        weight: 15,
+        goldValue: 10,
+        quantity: 1,
+        description: 'The most humble of items.',
       },
 
-      schoolOptions: [
-        'Abjuration',
-        'Conjuration',
-        'Divination',
-        'Enchantment',
-        'Evocation',
-        'Illusion',
-        'Necromancy',
-        'Transmutation',
+      typeOptions: [
+        'Armor',
+        'Potion',
+        'Ring',
+        'Rod',
+        'Scroll',
+        'Staff',
+        'Wand',
+        'Weapon',
+        'Wondrous Item',
       ],
 
-      concentrationOptions: [true, false],
+      rarityOptions: [
+        'Common',
+        'Uncommon',
+        'Rare',
+        'Very Rare',
+        'Legendary',
+        'Artifact',
+      ],
     };
   },
   /**
@@ -229,60 +225,19 @@ export default {
         });
     },
     /**
-     * Click handler for the 'create' button for the spell form.
-     */
-    async onComplete() {
-      /* TODO: validate inputs. */
-      await this.sendSpellCreationRequest();
-      /* TODO: cleanup creation form. */
-    },
-    /**
-     * @returns {Object} Properly-formatted spell data that can be sent
-     * the body of an HTTP request for spell creation.
+     * @returns {Object} Properly-formatted item data that can be sent
+     * the body of an HTTP request for item creation.
      */
     prepareDataForRequest() {
       return {
-        spell_name: this.spell.name,
-        level: parseInt(this.spell.level, 10),
-        school: this.spell.school,
-        concentration: this.spell.concentration,
-        casting_time: parseInt(this.spell.casting_time, 10),
-        duration: parseInt(this.spell.duration, 10),
-        range: parseInt(this.spell.range, 10),
-        description: this.spell.description,
+        item_name: this.item.name,
+        type: this.item.type,
+        rarity: this.item.rarity,
+        weight: parseInt(this.item.weight, 10),
+        gold_value: parseInt(this.item.goldValue, 10),
+        quantity: parseInt(this.item.quantity, 10),
+        description: this.item.description,
       };
-    },
-    /**
-     * Sends an HTTP request to the backend's spell creation API
-     * endpoint.
-     */
-    async sendSpellCreationRequest() {
-      const requestURI = `auth/character/${this.selectedCharacter.id}/spell`;
-      const method = 'POST';
-
-      await this.$http({
-        url: requestURI,
-        data: this.prepareDataForRequest(),
-        method,
-      })
-        .then(() => {
-          this.display({
-            message: 'Spell was successfully created!',
-            color: 'success',
-            timeout: 6000,
-          });
-        })
-        .catch((err) => {
-          let message = 'Something went wrong. Please try again.';
-          if (err.response) {
-            message = `Error: ${err.response.data.message}. Please try again.`;
-          }
-          this.display({
-            message,
-            color: 'error',
-            timeout: 6000,
-          });
-        });
     },
   },
 };

--- a/client/src/components/items/deletion/ItemDetails.vue
+++ b/client/src/components/items/deletion/ItemDetails.vue
@@ -1,0 +1,202 @@
+<!-- ItemDetails.vue -->
+<!-- Displays all details for a specific character's items.
+The player is then able to delete the item. -->
+
+<template>
+  <v-container class="item-info">
+    <!-- Character selection dropdown -->
+    <v-row>
+      <v-col cols="4">
+        <p class="headline primary--text">Select your character</p>
+        <v-select
+          solo
+          prepend-inner-icon="mdi-account-search"
+          :items="characterNames"
+          v-model="selectedCharName"
+        >
+          <!-- Button used to refresh the character list. -->
+          <template v-slot:append-outer>
+            <v-btn
+              color="primary"
+              fab
+              small
+              class="mt-n2"
+              @click="fetchUserCharacters"
+            >
+              <v-icon>mdi-refresh</v-icon>
+            </v-btn>
+          </template>
+        </v-select>
+      </v-col>
+
+      <!-- Item selection dropdown -->
+      <v-col cols="4" v-if="selectedCharName">
+        <p class="headline primary--text">Select your item</p>
+        <v-select
+          solo
+          no-data-text="This character has no items."
+          prepend-inner-icon="mdi-account-search"
+          :items="['Character Items Here']"
+        >
+          <!-- Button used to refresh the item list. -->
+          <template v-slot:append-outer>
+            <v-btn color="primary" fab small class="mt-n2">
+              <v-icon>mdi-refresh</v-icon>
+            </v-btn>
+          </template>
+        </v-select>
+      </v-col>
+
+      <!-- Item selection dropdown -->
+    </v-row>
+
+    <!-- Item Name -->
+    <v-card class="pl-2">
+      <v-card-title class="display-1 primary--text">
+        Item Name Here
+      </v-card-title>
+
+      <!-- Delete button -->
+      <v-btn class="error"> Delete Item </v-btn>
+
+      <!-- This container displays all item information -->
+      <v-container>
+        <p class="headline primary--text">Item Information</p>
+        <v-row>
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Type"
+              :value="'Item Type Here'"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Rarity"
+              :value="'Item Rarity Here'"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Weight"
+              :value="'Item Weight Here'"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Gold Value"
+              :value="'Item Gold Value Here'"
+            ></v-text-field>
+          </v-col>
+
+          <v-col cols="12" lg="2">
+            <v-text-field
+              readonly
+              label="Quantity"
+              :value="'Item Quantity Here'"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col cols="12" lg="12">
+            <v-textarea
+              readonly
+              no-resize
+              label="Description"
+              outlined
+              :value="'Item Description Here'"
+            ></v-textarea>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import { mapActions } from 'vuex';
+
+export default {
+  name: 'ItemDetails',
+  data() {
+    return {
+      characters: [],
+      selectedCharName: null,
+
+      items: [],
+      selectedItemName: null,
+    };
+  },
+  /**
+   * Fetches all of the user's character and item data when the component loads.
+   */
+  async created() {
+    await this.fetchUserCharacters();
+  },
+  computed: {
+    /**
+     * @returns {Array<String>} - The names of the user's characters (if
+     * any).
+     */
+    characterNames() {
+      if (this.characters === null) return [];
+      return this.characters.map((x) => x.name);
+    },
+    /**
+     * @returns {String} - The character currently selected by the user.
+     */
+    selectedCharacter() {
+      if (!this.selectedCharName) return {};
+
+      const target = this.selectedCharName;
+      return this.characters.filter((x) => x.name === target)[0];
+    },
+  },
+  methods: {
+    ...mapActions({
+      display: 'notifications/display',
+    }),
+    /**
+     * Sends an HTTP request to fetch the user's characters.
+     */
+    async fetchUserCharacters() {
+      const requestURI = 'auth/character/me';
+      const method = 'GET';
+
+      await this.$http({
+        url: requestURI,
+        data: null,
+        method,
+      })
+        .then((resp) => {
+          const fetchedCharacters = resp.data.data.characters;
+          if (fetchedCharacters) {
+            this.characters = fetchedCharacters;
+            this.selectedCharName = fetchedCharacters[0].name;
+          } else {
+            this.characters = [];
+            this.selectedCharName = null;
+          }
+        })
+        .catch((err) => {
+          let message = 'Could not fetch characters. Please try again.';
+          if (err.response) {
+            message = `Error: ${err.response.data.message}. Please try again.`;
+          }
+          this.display({
+            message,
+            color: 'error',
+            timeout: 10000,
+          });
+        });
+    },
+  },
+};
+</script>

--- a/client/src/layouts/NavDrawer.vue
+++ b/client/src/layouts/NavDrawer.vue
@@ -41,6 +41,7 @@ export default {
         { title: 'Dashboard', icon: 'mdi-view-dashboard', to: '/dashboard' },
         { title: 'My account', icon: 'mdi-account-box', to: '/account' },
         { title: 'Character management', icon: 'mdi-gavel', to: '/characters' },
+        { title: 'Item management', icon: 'mdi-sword-cross', to: '/items' },
         { title: 'Spell management', icon: 'mdi-fire', to: '/spells' },
         { title: 'Start a campaign', icon: 'mdi-castle', to: '/campaign' },
       ],

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -64,6 +64,16 @@ const routes = [
     },
   },
   {
+
+    path: '/items',
+    name: 'Itmes',
+    component: () => import('../views/Items.vue'),
+    meta: {
+      layout: 'Main',
+      protected: true,
+    },
+  },
+  {
     path: '/spells',
     name: 'Spells',
     component: () => import('../views/Spells.vue'),

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -66,7 +66,7 @@ const routes = [
   {
 
     path: '/items',
-    name: 'Itmes',
+    name: 'Items',
     component: () => import('../views/Items.vue'),
     meta: {
       layout: 'Main',

--- a/client/src/views/Items.vue
+++ b/client/src/views/Items.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="characters">
+    <ItemManagement />
+  </div>
+</template>
+
+<script>
+import ItemManagement from '../components/items/ItemManagement.vue';
+
+export default {
+  name: 'Items',
+  components: {
+    ItemManagement,
+  },
+};
+</script>


### PR DESCRIPTION
This pull request has a nearly identical frontend as the Spells Creation / Deletion PR from yesterday. There is no backend logic except for the fetch characters. I tried to remove it all to make it as clean as possible. This should be ready for backend connection. I have put placeholders in the spots where item data will go. See line 70 in ItemDetails.vue as an example. 

![image](https://user-images.githubusercontent.com/47066061/114653958-fccca280-9c9d-11eb-94ba-97a671a53582.png)

![image](https://user-images.githubusercontent.com/47066061/114653970-03f3b080-9c9e-11eb-87fd-c4cc68f939d7.png)
