### PR TITLE
Simplify navbar section names

### DIFF
--- a/client/src/layouts/NavDrawer.vue
+++ b/client/src/layouts/NavDrawer.vue
@@ -40,10 +40,10 @@ export default {
         /* TODO: update links when they are created */
         { title: 'Dashboard', icon: 'mdi-view-dashboard', to: '/dashboard' },
         { title: 'My account', icon: 'mdi-account-box', to: '/account' },
-        { title: 'Character management', icon: 'mdi-gavel', to: '/characters' },
-        { title: 'Item management', icon: 'mdi-sword-cross', to: '/items' },
-        { title: 'Spell management', icon: 'mdi-fire', to: '/spells' },
-        { title: 'Start a campaign', icon: 'mdi-castle', to: '/campaign' },
+        { title: 'Characters', icon: 'mdi-gavel', to: '/characters' },
+        { title: 'Items', icon: 'mdi-sword-cross', to: '/items' },
+        { title: 'Spells', icon: 'mdi-fire', to: '/spells' },
+        { title: 'Campaigns', icon: 'mdi-castle', to: '/campaign' },
       ],
     };
   },


### PR DESCRIPTION
I think simpler is better here. Looks cleaner in my opinion.

![image](https://user-images.githubusercontent.com/31908183/114813923-edb22700-9d67-11eb-8a08-157db3020d92.png)
